### PR TITLE
Update main.ml

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -30,8 +30,8 @@ let run_miou () =
       Format.printf "awaiting all %d children [live_words=%d]\r\n%!"
         (child_count) (live_words ());
       Miou.await_all children |> ignore;
-      (* NOTE(leostera): it appears that even triggering a full major gc won't
-         clean up the children's memory. *)
+      Miou.yield ();
+      full_major ();
       full_major ();
       Format.printf "all %d children have returned [live_words=%d]\r\n%!"
         (child_count) (live_words ())


### PR DESCRIPTION
Fix the memory leak.

To really understand why all your promises are kept even if ignore them (and I talk only about Miou here) is because:
1) `Miou‧await_all` produces an effect which will switch to another stack and call our [`await`](https://github.com/robur-coop/miou/blob/b38dcca19fb1e7a2ff1f22b5c54b9c7a4043e722/lib/miou.ml#L974-L1050) function. In your specific case, all your promises are resolved (they don't block/don't emit an effect). So we fallback to the [`all_terminated`](https://github.com/robur-coop/miou/blob/b38dcca19fb1e7a2ff1f22b5c54b9c7a4043e722/lib/miou.ml#L1040-L1049) situation.
2) In this situation, we want to _continue_ the given continuation`k` (again, because everything is finished). In that case, we have 2 stack:
    * a stack for our internal `await` function which **keep** the list of our promises
    * a stack which will continue what we have after our `Miou‧await_all` and we actually execute this stack
3) so even if we call `full_major` after our `ignore`, concretely our other stack for our internal `await` still exists (with its list of promises) because its the stack which [execute the continuation](https://github.com/robur-coop/miou/blob/b38dcca19fb1e7a2ff1f22b5c54b9c7a4043e722/lib/miou.ml#L1045)
4) To be able to forget "in advance" all of these promises, the continuation must stop somewhere. Before this commit, the continuation stops when the parent stop. After this commit, the continuation stops at the `Miou‧yield`. So, after it, we come back to our internal `await` (which does nothing else) and we can really forget all promises then.
5) Finally, the double `full_major` is needed to (1) mark our datas as free (2) free them.

It's clearly not optimal behaviour where we really want to forget everything, but that's how things work 🙅.